### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -28,7 +28,7 @@ jobs:
         run: docker build -t migsking/dsm-payments .
 
       - name: publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: migsking/dsm-payments
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore